### PR TITLE
ZNetScene QOL, Trader method

### DIFF
--- a/ItemManager/ItemManager.cs
+++ b/ItemManager/ItemManager.cs
@@ -771,7 +771,14 @@ public static class PrefabManager
 	{
 		foreach (GameObject prefab in prefabs.Concat(ZnetOnlyPrefabs))
 		{
-			__instance.m_prefabs.Add(prefab);
+			if (!__instance.m_prefabs.Contains(prefab))
+			{
+				__instance.m_prefabs.Add(prefab);
+			}
+			else
+			{
+				Debug.LogWarning($"ZNetScene already contains {prefab.name} it cannot be added twice.");
+			}
 		}
 	}
 }


### PR DESCRIPTION
I chose the method way for AddToTrader because it seemed more simple than doing something like prefab.Trader.Add()

[Check if ZNetScene already has prefab before trying to add it.](https://github.com/blaxxun-boop/ItemManager/commit/c978bb069e19a3cd260da6f22bfb0cf40d1f65ae)

[Add method to add your item to the trader (vanilla way currently)](https://github.com/blaxxun-boop/ItemManager/commit/ceb26fa3178996fe825db6d41b3115f3328fe7ca)

