### PR TITLE
Fix for new Localization() call

### DIFF
--- a/ItemManager/ItemManager.cs
+++ b/ItemManager/ItemManager.cs
@@ -1772,6 +1772,7 @@ public static class LocalizationCache
 		{
 			return localization;
 		}
+		var _ = Localization.instance;
 		localization = new Localization();
 		if (language is not null)
 		{


### PR DESCRIPTION
If new Localization() is used before any other mod / game called Localization.instance then it won't call Initialize to set Localization.m_localizationSettings, which leads to NRE